### PR TITLE
Use get_queryset instead of get_query_set

### DIFF
--- a/logicaldelete/managers.py
+++ b/logicaldelete/managers.py
@@ -9,27 +9,27 @@ class LogicalDeletedManager(models.Manager):
     providing the filtering out of logically deleted objects.  In addition, it
     provides named querysets for getting the deleted objects.
     """
-    
-    def get_query_set(self):
+
+    def get_queryset(self):
         if self.model:
             return LogicalDeleteQuerySet(self.model, using=self._db).filter(
                 date_removed__isnull=True
             )
-    
+
     def all_with_deleted(self):
         if self.model:
-            return super(LogicalDeletedManager, self).get_query_set()
-    
+            return super(LogicalDeletedManager, self).get_queryset()
+
     def only_deleted(self):
         if self.model:
-            return super(LogicalDeletedManager, self).get_query_set().filter(
+            return super(LogicalDeletedManager, self).get_queryset().filter(
                 date_removed__isnull=False
             )
-    
+
     def get(self, *args, **kwargs):
         return self.all_with_deleted().get(*args, **kwargs)
-    
+
     def filter(self, *args, **kwargs):
         if "pk" in kwargs:
             return self.all_with_deleted().filter(*args, **kwargs)
-        return self.get_query_set().filter(*args, **kwargs)
+        return self.get_queryset().filter(*args, **kwargs)


### PR DESCRIPTION
Starting in Django 1.8, get_query_set will now be get_queryset. This change was
announced as part of the Django 1.6 release and now in Django 1.7 throws a
RemovedInDjango18Warning. See:

https://docs.djangoproject.com/en/1.7/releases/1.6/#get-query-set-and-similar-methods-renamed-to-get-queryset
