### PR TITLE
Remove fields date_created and date_modified

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,9 +81,7 @@ Using the app is pretty simple:
 Additional
 ----------
 
-Logical deletes are handled by date stamping a `date_removed` column.  In
-addition, a ``date_created`` and ``date_modified`` columns will be populated as a
-convenience.
+Logical deletes are handled by date stamping a `date_removed` column.
 
 
 Backwards Incompatible Changes

--- a/pinax/models/models.py
+++ b/pinax/models/models.py
@@ -10,8 +10,6 @@ class LogicalDeleteModel(models.Model):
     This base model provides date fields and functionality to enable logical
     delete functionality in derived models.
     """
-    date_created = models.DateTimeField(default=timezone.now)
-    date_modified = models.DateTimeField(default=timezone.now)
     date_removed = models.DateTimeField(null=True, blank=True)
 
     objects = managers.LogicalDeletedManager()


### PR DESCRIPTION
These fields are redundant for logical deletion.
Model itself named ``LogicalDeleteModel`` and seeing
this fields inside it are surprising.

Also, there are a few apps that provide similarly
functionality:

* https://github.com/django-extensions/django-extensions
  It has ``django_extensions.db.models.TimeStampedModel``
* https://github.com/carljm/django-model-utils
  It has ``model_utils.models.TimeStampedModel``

So if somebody started to use one of this app or some another,
and then wants to start using ``pinax-models`` with logical
delete feature, he will get confusing by duplicating fields