### PR TITLE
Fix deletion of inherted models

### DIFF
--- a/pinax/models/models.py
+++ b/pinax/models/models.py
@@ -25,7 +25,9 @@ class LogicalDeleteModel(models.Model):
         to_delete = get_related_objects(self)
 
         for obj in to_delete:
-            obj.delete()
+            # check that model is not inherited to avoid circular deletion
+            if not issubclass(obj.__class__, self.__class__):
+                obj.delete()
 
         # Soft delete the object
         self.date_removed = timezone.now()


### PR DESCRIPTION
As referenced in #13, not all related objects should be deleted.

But I think that ``ForeignKey`` should resolve it by itself, using ``on_delete`` param. The same applies to ``OneToOneField``.

But there is another case with inherited models.
Consider following case:

```
class BaseModel(UndeleteBase):
    name = models.CharField(default='Empty name', max_length=256)

class InhertedModel(BaseModel):
    description = models.TextField(default='Some description')
```

In this case, when the instance of ``InhertedModel`` would be deleted, related objects will contain linked the instance of ``BaseModel`` and it's ``delete`` method will be called. Which collect instance of ``InhertedModel`` in related objects and call it's ``delete`` method.
So we will have endless recursion.

This commit fixes it