### PR TITLE
Fixed dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,18 @@ env:
   - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=1.10
+  - DJANGO=1.11
   - DJANGO=master
 matrix:
   exclude:
+    - python: "2.7"
+      env: DJANGO=master
     - python: "3.3"
       env: DJANGO=1.9
     - python: "3.3"
       env: DJANGO=1.10
+    - python: "3.3"
+      env: DJANGO=1.11
     - python: "3.3"
       env: DJANGO=master
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@ exclude = migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.8,1.9,1.10,master},
+    py27-{1.8,1.9,1.10,1.11},
     py33-{1.8},
-    py34-{1.8,1.9,1.10,master},
-    py35-{1.8,1.9,1.10,master}
+    py34-{1.8,1.9,1.10,1.11,master},
+    py35-{1.8,1.9,1.10,1.11,master}
 
 [testenv]
 deps =
@@ -18,6 +18,7 @@ deps =
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
+    1.11: https://github.com/django/django/tree/stable/1.11.x
     master: https://github.com/django/django/tarball/master
 usedevelop = True
 setenv =


### PR DESCRIPTION
django/master is now version 2 which is incompatible with 2.7
Added 1.11 version and restricted master to supported Python versions.