### PR TITLE
Correctly filter related models using parent model

### DIFF
--- a/pinax/models/managers.py
+++ b/pinax/models/managers.py
@@ -17,13 +17,16 @@ class LogicalDeletedManager(models.Manager):
 
     def all_with_deleted(self):
         if self.model:
+            if hasattr(self, 'core_filters'):
+                return super(LogicalDeletedManager, self).get_queryset().filter(**self.core_filters)
             return super(LogicalDeletedManager, self).get_queryset()
 
     def only_deleted(self):
         if self.model:
-            return super(LogicalDeletedManager, self).get_queryset().filter(
-                date_removed__isnull=False
-            )
+            filters = { 'date_removed__isnull': False }
+            if hasattr(self, 'core_filters'):
+                filters.update(**self.core_filters)
+            return super(LogicalDeletedManager, self).get_queryset().filter(filters)
 
     def get(self, *args, **kwargs):
         return self.all_with_deleted().get(*args, **kwargs)


### PR DESCRIPTION
Normally when you call a manager based on a related model (e.g. record.children.all()), it adds filters so that only records for that model are returned. Because `all_with_deleted` and `only_deleted` use the base queryset, those filters are not included. This change ensures that `record.children.all_with_deleted()` and `record.children.only_deleted()` only pull in records for the parent record.